### PR TITLE
Add TMW SEO Autopilot 100 — Phase 1 (Source files only, Serper + OpenAI base)

### DIFF
--- a/tmw-seo-autopilot-100/README.md
+++ b/tmw-seo-autopilot-100/README.md
@@ -1,0 +1,34 @@
+# TMW SEO Autopilot 100
+
+Phase 1 of the **TMW SEO Autopilot 100** plugin delivers Serper-driven keyword intelligence and OpenAI-assisted outline generation directly within WordPress.
+
+## Features
+- **Serper Integration** – Transform SERP data into keyword clusters and questions.
+- **OpenAI Outlines** – Draft ready-to-edit content briefs with a single click.
+- **REST API Endpoints** – Automate workflows through `/tmw-sa100/v1` endpoints.
+- **Diagnostics Dashboard** – Monitor integration health and configuration.
+
+## Requirements
+- WordPress 6.0+
+- PHP 7.4+
+- Valid Serper API key
+- Valid OpenAI API key
+
+## Installation
+1. Upload the plugin folder `tmw-seo-autopilot-100` to `/wp-content/plugins/`.
+2. Activate the plugin via the WordPress Admin → Plugins screen.
+3. Navigate to **SEO Autopilot → Integrations** to store your API credentials.
+4. Launch the **Keyword Engine** and **Content Draft** tools from the admin menu.
+
+## REST Endpoints
+| Method | Route | Description |
+| --- | --- | --- |
+| `POST` | `/tmw-sa100/v1/keyword-plan` | Build keyword clusters for provided keywords. |
+| `POST` | `/tmw-sa100/v1/content-draft` | Generate an OpenAI-powered outline draft. |
+| `GET/POST` | `/tmw-sa100/v1/settings` | Retrieve or update plugin integration settings. |
+
+## Development
+The plugin uses a lightweight autoloader registered in `tmw-seo-autopilot-100.php`. Classes live inside the `core/` and `classes/` directories, while admin templates can be found under `admin/views/`.
+
+## Uninstall
+Removing the plugin triggers the uninstall script to clean up saved options.

--- a/tmw-seo-autopilot-100/admin/assets/admin.css
+++ b/tmw-seo-autopilot-100/admin/assets/admin.css
@@ -1,0 +1,33 @@
+.tmw-sa100-wrap {
+    max-width: 960px;
+}
+
+.tmw-sa100-card {
+    background: #fff;
+    border-radius: 6px;
+    padding: 24px;
+    margin-bottom: 24px;
+    box-shadow: 0 15px 35px rgba(30, 47, 74, 0.08);
+}
+
+.tmw-sa100-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.tmw-sa100-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: #3858e9;
+    color: #fff;
+    font-weight: 600;
+    font-size: 12px;
+    letter-spacing: .05em;
+}
+
+.tmw-sa100-table td,
+.tmw-sa100-table th {
+    padding: 8px 12px;
+}

--- a/tmw-seo-autopilot-100/admin/assets/admin.js
+++ b/tmw-seo-autopilot-100/admin/assets/admin.js
@@ -1,0 +1,89 @@
+(function ($) {
+    'use strict';
+
+    function postJSON(endpoint, data) {
+        return wp.apiRequest({
+            path: endpoint,
+            method: 'POST',
+            data: data,
+        });
+    }
+
+    $(function () {
+        var keywordForm = $('#tmw-sa100-keyword-form');
+        var contentForm = $('#tmw-sa100-content-form');
+        var settingsForm = $('#tmw-sa100-settings-form');
+
+        if (keywordForm.length) {
+            keywordForm.on('submit', function (event) {
+                event.preventDefault();
+
+                var keywords = keywordForm.find('textarea[name="keywords"]').val().split('\n').filter(Boolean);
+                var locale = keywordForm.find('select[name="locale"]').val();
+                var output = keywordForm.find('.tmw-sa100-output');
+
+                output.text(keywordForm.data('loading'));
+
+                postJSON('tmw-sa100/v1/keyword-plan', {
+                    keywords: keywords,
+                    locale: locale,
+                })
+                    .done(function (response) {
+                        output.text(JSON.stringify(response, null, 2));
+                    })
+                    .fail(function (error) {
+                        output.text(error.responseJSON && error.responseJSON.message ? error.responseJSON.message : error.statusText);
+                    });
+            });
+        }
+
+        if (contentForm.length) {
+            contentForm.on('submit', function (event) {
+                event.preventDefault();
+
+                var topic = contentForm.find('input[name="topic"]').val();
+                var outline = contentForm.find('textarea[name="outline"]').val().split('\n').filter(Boolean);
+                var output = contentForm.find('.tmw-sa100-output');
+
+                output.text(contentForm.data('loading'));
+
+                postJSON('tmw-sa100/v1/content-draft', {
+                    topic: topic,
+                    outline: outline,
+                })
+                    .done(function (response) {
+                        output.text(response);
+                    })
+                    .fail(function (error) {
+                        output.text(error.responseJSON && error.responseJSON.message ? error.responseJSON.message : error.statusText);
+                    });
+            });
+        }
+
+        if (settingsForm.length) {
+            settingsForm.on('submit', function (event) {
+                event.preventDefault();
+
+                var data = {
+                    serper_api_key: settingsForm.find('input[name="serper_api_key"]').val(),
+                    openai_api_key: settingsForm.find('input[name="openai_api_key"]').val(),
+                    default_locale: settingsForm.find('select[name="default_locale"]').val(),
+                };
+
+                settingsForm.find('.tmw-sa100-status').text(settingsForm.data('loading'));
+
+                wp.apiRequest({
+                    path: 'tmw-sa100/v1/settings',
+                    method: 'POST',
+                    data: data,
+                })
+                    .done(function () {
+                        settingsForm.find('.tmw-sa100-status').text(settingsForm.data('success'));
+                    })
+                    .fail(function (error) {
+                        settingsForm.find('.tmw-sa100-status').text(error.responseJSON && error.responseJSON.message ? error.responseJSON.message : error.statusText);
+                    });
+            });
+        }
+    });
+})(jQuery);

--- a/tmw-seo-autopilot-100/admin/views/dashboard.php
+++ b/tmw-seo-autopilot-100/admin/views/dashboard.php
@@ -1,0 +1,38 @@
+<?php
+/** @var TMW\SA100\Classes\Settings $settings */
+?>
+<div class="wrap tmw-sa100-wrap">
+    <h1><?php esc_html_e('TMW SEO Autopilot 100', 'tmw-seo-autopilot-100'); ?></h1>
+
+    <div class="tmw-sa100-card">
+        <span class="tmw-sa100-badge"><?php esc_html_e('Phase 1', 'tmw-seo-autopilot-100'); ?></span>
+        <h2><?php esc_html_e('Serper + OpenAI Automation', 'tmw-seo-autopilot-100'); ?></h2>
+        <p><?php esc_html_e('Automate your keyword research and AI-assisted outline creation with streamlined workflows.', 'tmw-seo-autopilot-100'); ?></p>
+    </div>
+
+    <div class="tmw-sa100-grid">
+        <div class="tmw-sa100-card">
+            <h3><?php esc_html_e('Keyword Intelligence', 'tmw-seo-autopilot-100'); ?></h3>
+            <p><?php esc_html_e('Serper analysis converts live SERP data into actionable keyword clusters.', 'tmw-seo-autopilot-100'); ?></p>
+        </div>
+
+        <div class="tmw-sa100-card">
+            <h3><?php esc_html_e('OpenAI Content Drafts', 'tmw-seo-autopilot-100'); ?></h3>
+            <p><?php esc_html_e('Jumpstart content briefs with contextual outlines ready for editorial refinement.', 'tmw-seo-autopilot-100'); ?></p>
+        </div>
+
+        <div class="tmw-sa100-card">
+            <h3><?php esc_html_e('Integrations Dashboard', 'tmw-seo-autopilot-100'); ?></h3>
+            <p><?php esc_html_e('Manage API credentials, locales, and workflow defaults in one interface.', 'tmw-seo-autopilot-100'); ?></p>
+        </div>
+    </div>
+
+    <div class="tmw-sa100-card">
+        <h3><?php esc_html_e('Quick Actions', 'tmw-seo-autopilot-100'); ?></h3>
+        <ul>
+            <li><a href="<?php echo esc_url(admin_url('admin.php?page=tmw-sa100-keyword-engine')); ?>"><?php esc_html_e('Launch Keyword Engine', 'tmw-seo-autopilot-100'); ?></a></li>
+            <li><a href="<?php echo esc_url(admin_url('admin.php?page=tmw-sa100-integrations')); ?>"><?php esc_html_e('Configure Integrations', 'tmw-seo-autopilot-100'); ?></a></li>
+            <li><a href="<?php echo esc_url(admin_url('admin.php?page=tmw-sa100-diagnostics')); ?>"><?php esc_html_e('Run Diagnostics', 'tmw-seo-autopilot-100'); ?></a></li>
+        </ul>
+    </div>
+</div>

--- a/tmw-seo-autopilot-100/admin/views/diagnostics.php
+++ b/tmw-seo-autopilot-100/admin/views/diagnostics.php
@@ -1,0 +1,42 @@
+<?php
+/** @var TMW\SA100\Classes\Settings $settings */
+/** @var array $connection_checks */
+?>
+<div class="wrap tmw-sa100-wrap">
+    <h1><?php esc_html_e('Diagnostics', 'tmw-seo-autopilot-100'); ?></h1>
+
+    <div class="tmw-sa100-card">
+        <h2><?php esc_html_e('Connection Status', 'tmw-seo-autopilot-100'); ?></h2>
+        <table class="widefat tmw-sa100-table">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e('Service', 'tmw-seo-autopilot-100'); ?></th>
+                    <th><?php esc_html_e('Status', 'tmw-seo-autopilot-100'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><?php esc_html_e('Serper API', 'tmw-seo-autopilot-100'); ?></td>
+                    <td><?php echo ! empty($connection_checks['serper']) ? esc_html__('Online', 'tmw-seo-autopilot-100') : esc_html__('Offline', 'tmw-seo-autopilot-100'); ?></td>
+                </tr>
+                <tr>
+                    <td><?php esc_html_e('OpenAI API', 'tmw-seo-autopilot-100'); ?></td>
+                    <td><?php echo ! empty($connection_checks['openai']) ? esc_html__('Online', 'tmw-seo-autopilot-100') : esc_html__('Offline', 'tmw-seo-autopilot-100'); ?></td>
+                </tr>
+                <tr>
+                    <td><?php esc_html_e('Site Frontend', 'tmw-seo-autopilot-100'); ?></td>
+                    <td><?php echo ! empty($connection_checks['wordpress']) ? esc_html__('Reachable', 'tmw-seo-autopilot-100') : esc_html__('Unreachable', 'tmw-seo-autopilot-100'); ?></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="tmw-sa100-card">
+        <h2><?php esc_html_e('Current Configuration', 'tmw-seo-autopilot-100'); ?></h2>
+        <ul>
+            <li><?php esc_html_e('Default Locale:', 'tmw-seo-autopilot-100'); ?> <strong><?php echo esc_html($settings->get('default_locale')); ?></strong></li>
+            <li><?php esc_html_e('Serper API Key:', 'tmw-seo-autopilot-100'); ?> <strong><?php echo $settings->get('serper_api_key') ? esc_html__('Set', 'tmw-seo-autopilot-100') : esc_html__('Not Set', 'tmw-seo-autopilot-100'); ?></strong></li>
+            <li><?php esc_html_e('OpenAI API Key:', 'tmw-seo-autopilot-100'); ?> <strong><?php echo $settings->get('openai_api_key') ? esc_html__('Set', 'tmw-seo-autopilot-100') : esc_html__('Not Set', 'tmw-seo-autopilot-100'); ?></strong></li>
+        </ul>
+    </div>
+</div>

--- a/tmw-seo-autopilot-100/admin/views/integrations.php
+++ b/tmw-seo-autopilot-100/admin/views/integrations.php
@@ -1,0 +1,42 @@
+<?php
+/** @var TMW\SA100\Classes\Settings $settings */
+?>
+<div class="wrap tmw-sa100-wrap">
+    <h1><?php esc_html_e('Integrations', 'tmw-seo-autopilot-100'); ?></h1>
+
+    <div class="tmw-sa100-card">
+        <form id="tmw-sa100-settings-form" data-loading="<?php esc_attr_e('Saving…', 'tmw-seo-autopilot-100'); ?>" data-success="<?php esc_attr_e('Settings saved.', 'tmw-seo-autopilot-100'); ?>">
+            <?php wp_nonce_field('tmw-sa100-settings', 'tmw_sa100_settings_nonce'); ?>
+            <table class="form-table">
+                <tr>
+                    <th scope="row"><label for="tmw-sa100-serper"><?php esc_html_e('Serper API Key', 'tmw-seo-autopilot-100'); ?></label></th>
+                    <td>
+                        <input type="password" id="tmw-sa100-serper" name="serper_api_key" class="regular-text" value="<?php echo esc_attr($settings->get('serper_api_key')); ?>">
+                        <p class="description"><?php esc_html_e('Required for live SERP intelligence.', 'tmw-seo-autopilot-100'); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="tmw-sa100-openai"><?php esc_html_e('OpenAI API Key', 'tmw-seo-autopilot-100'); ?></label></th>
+                    <td>
+                        <input type="password" id="tmw-sa100-openai" name="openai_api_key" class="regular-text" value="<?php echo esc_attr($settings->get('openai_api_key')); ?>">
+                        <p class="description"><?php esc_html_e('Used for outline generation and AI prompts.', 'tmw-seo-autopilot-100'); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="tmw-sa100-default-locale"><?php esc_html_e('Default Locale', 'tmw-seo-autopilot-100'); ?></label></th>
+                    <td>
+                        <select name="default_locale" id="tmw-sa100-default-locale">
+                            <?php $selected_locale = $settings->get('default_locale'); ?>
+                            <option value="en" <?php selected($selected_locale, 'en'); ?>>English</option>
+                            <option value="es" <?php selected($selected_locale, 'es'); ?>>Español</option>
+                            <option value="de" <?php selected($selected_locale, 'de'); ?>>Deutsch</option>
+                            <option value="fr" <?php selected($selected_locale, 'fr'); ?>>Français</option>
+                        </select>
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(__('Save Integrations', 'tmw-seo-autopilot-100')); ?>
+            <p class="tmw-sa100-status" aria-live="polite"></p>
+        </form>
+    </div>
+</div>

--- a/tmw-seo-autopilot-100/admin/views/keyword-engine.php
+++ b/tmw-seo-autopilot-100/admin/views/keyword-engine.php
@@ -1,0 +1,37 @@
+<?php
+/** @var TMW\SA100\Classes\Task_Runner $task_runner */
+?>
+<div class="wrap tmw-sa100-wrap">
+    <h1><?php esc_html_e('Keyword Engine', 'tmw-seo-autopilot-100'); ?></h1>
+
+    <div class="tmw-sa100-card">
+        <p><?php esc_html_e('Generate keyword clusters from Serper data and export them to your editorial pipeline.', 'tmw-seo-autopilot-100'); ?></p>
+
+        <form id="tmw-sa100-keyword-form" data-loading="<?php esc_attr_e('Crunching keywords…', 'tmw-seo-autopilot-100'); ?>">
+            <?php wp_nonce_field('tmw-sa100-keyword', 'tmw_sa100_keyword_nonce'); ?>
+            <table class="form-table">
+                <tr>
+                    <th scope="row"><label for="tmw-sa100-keywords"><?php esc_html_e('Seed Keywords', 'tmw-seo-autopilot-100'); ?></label></th>
+                    <td>
+                        <textarea name="keywords" id="tmw-sa100-keywords" rows="5" class="large-text" placeholder="seo automation\nwordpress ai"></textarea>
+                        <p class="description"><?php esc_html_e('Enter one keyword per line for best results.', 'tmw-seo-autopilot-100'); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="tmw-sa100-locale"><?php esc_html_e('Locale', 'tmw-seo-autopilot-100'); ?></label></th>
+                    <td>
+                        <select name="locale" id="tmw-sa100-locale">
+                            <option value="us">US</option>
+                            <option value="uk">UK</option>
+                            <option value="de">DE</option>
+                            <option value="es">ES</option>
+                        </select>
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(__('Generate Plan', 'tmw-seo-autopilot-100')); ?>
+        </form>
+
+        <pre class="tmw-sa100-output"></pre>
+    </div>
+</div>

--- a/tmw-seo-autopilot-100/classes/class-keyword-engine.php
+++ b/tmw-seo-autopilot-100/classes/class-keyword-engine.php
@@ -1,0 +1,56 @@
+<?php
+namespace TMW\SA100\Classes;
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Provides keyword clustering helpers.
+ */
+class Keyword_Engine
+{
+    /**
+     * Build keyword clusters from Serper results.
+     *
+     * @param array  $results Serper results payload.
+     * @param string $seed    Seed keyword.
+     *
+     * @return array
+     */
+    public function build_clusters(array $results, $seed)
+    {
+        $clusters = [
+            'primary'   => [],
+            'secondary' => [],
+            'questions' => [],
+        ];
+
+        if (! empty($results['organic'])) {
+            foreach ($results['organic'] as $item) {
+                if (! empty($item['title'])) {
+                    $clusters['primary'][] = sanitize_text_field($item['title']);
+                }
+
+                if (! empty($item['snippet'])) {
+                    $clusters['secondary'][] = sanitize_text_field($item['snippet']);
+                }
+            }
+        }
+
+        if (! empty($results['relatedSearches'])) {
+            foreach ($results['relatedSearches'] as $search) {
+                $clusters['questions'][] = sanitize_text_field($search['query']);
+            }
+        }
+
+        $clusters['primary']   = array_values(array_unique($clusters['primary']));
+        $clusters['secondary'] = array_values(array_unique($clusters['secondary']));
+        $clusters['questions'] = array_values(array_unique($clusters['questions']));
+
+        return [
+            'seed'     => $seed,
+            'clusters' => $clusters,
+        ];
+    }
+}

--- a/tmw-seo-autopilot-100/classes/class-openai-client.php
+++ b/tmw-seo-autopilot-100/classes/class-openai-client.php
@@ -1,0 +1,75 @@
+<?php
+namespace TMW\SA100\Classes;
+
+use WP_Error;
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Minimal OpenAI REST client for generating marketing content.
+ */
+class OpenAI_Client
+{
+    const API_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+
+    /**
+     * Settings handler.
+     *
+     * @var Settings
+     */
+    protected $settings;
+
+    /**
+     * Constructor.
+     *
+     * @param Settings $settings Settings class instance.
+     */
+    public function __construct(Settings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Request a chat completion response.
+     *
+     * @param array  $messages Conversation messages.
+     * @param string $model    Model identifier.
+     *
+     * @return array|WP_Error
+     */
+    public function chat(array $messages, $model = 'gpt-4o-mini')
+    {
+        $api_key = $this->settings->get('openai_api_key');
+
+        if (empty($api_key)) {
+            return new WP_Error('tmw_sa100_missing_openai_key', __('OpenAI API key is missing.', 'tmw-seo-autopilot-100'));
+        }
+
+        $response = wp_remote_post(static::API_ENDPOINT, [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $api_key,
+                'Content-Type'  => 'application/json',
+            ],
+            'body'    => wp_json_encode([
+                'model'       => $model,
+                'messages'    => $messages,
+                'temperature' => 0.4,
+            ]),
+            'timeout' => 30,
+        ]);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $data = json_decode(wp_remote_retrieve_body($response), true);
+
+        if (! is_array($data) || empty($data['choices'][0]['message']['content'])) {
+            return new WP_Error('tmw_sa100_invalid_openai_response', __('Unexpected OpenAI response.', 'tmw-seo-autopilot-100'));
+        }
+
+        return $data['choices'][0]['message']['content'];
+    }
+}

--- a/tmw-seo-autopilot-100/classes/class-serper-client.php
+++ b/tmw-seo-autopilot-100/classes/class-serper-client.php
@@ -1,0 +1,76 @@
+<?php
+namespace TMW\SA100\Classes;
+
+use WP_Error;
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Lightweight client for the Serper search API.
+ */
+class Serper_Client
+{
+    const API_ENDPOINT = 'https://google.serper.dev/search';
+
+    /**
+     * Plugin settings handler.
+     *
+     * @var Settings
+     */
+    protected $settings;
+
+    /**
+     * Constructor.
+     *
+     * @param Settings $settings Settings object.
+     */
+    public function __construct(Settings $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Execute a keyword search.
+     *
+     * @param string $keyword Keyword to search.
+     * @param string $locale  Optional locale.
+     *
+     * @return array|WP_Error
+     */
+    public function search($keyword, $locale = 'us')
+    {
+        $api_key = $this->settings->get('serper_api_key');
+
+        if (empty($api_key)) {
+            return new WP_Error('tmw_sa100_missing_serper_key', __('Serper API key is missing.', 'tmw-seo-autopilot-100'));
+        }
+
+        $response = wp_remote_post(static::API_ENDPOINT, [
+            'headers' => [
+                'X-API-KEY'    => $api_key,
+                'Content-Type' => 'application/json',
+            ],
+            'body'    => wp_json_encode([
+                'q'      => $keyword,
+                'gl'     => $locale,
+                'hl'     => substr($locale, 0, 2),
+                'num'    => 10,
+            ]),
+            'timeout' => 20,
+        ]);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $data = json_decode(wp_remote_retrieve_body($response), true);
+
+        if (! is_array($data)) {
+            return new WP_Error('tmw_sa100_invalid_serper_response', __('Unexpected Serper response.', 'tmw-seo-autopilot-100'));
+        }
+
+        return $data;
+    }
+}

--- a/tmw-seo-autopilot-100/classes/class-settings.php
+++ b/tmw-seo-autopilot-100/classes/class-settings.php
@@ -1,0 +1,94 @@
+<?php
+namespace TMW\SA100\Classes;
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Manages plugin configuration values stored in the options table.
+ */
+class Settings
+{
+    const OPTION_KEY = 'tmw_sa100_settings';
+
+    /**
+     * Cached settings array.
+     *
+     * @var array
+     */
+    protected $settings = [];
+
+    /**
+     * Constructor loads settings.
+     */
+    public function __construct()
+    {
+        $this->settings = get_option(static::OPTION_KEY, [
+            'serper_api_key' => '',
+            'openai_api_key' => '',
+            'default_locale' => 'en',
+        ]);
+    }
+
+    /**
+     * Activation routine ensures defaults exist.
+     *
+     * @return void
+     */
+    public static function activate()
+    {
+        if (! get_option(static::OPTION_KEY)) {
+            add_option(static::OPTION_KEY, [
+                'serper_api_key' => '',
+                'openai_api_key' => '',
+                'default_locale' => 'en',
+            ]);
+        }
+    }
+
+    /**
+     * Deactivation clean-up routine.
+     *
+     * @return void
+     */
+    public static function deactivate()
+    {
+        // Intentionally left for future scheduled cleanup.
+    }
+
+    /**
+     * Retrieve all settings.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->settings;
+    }
+
+    /**
+     * Retrieve a single setting value.
+     *
+     * @param string $key Setting key.
+     *
+     * @return mixed|null
+     */
+    public function get($key)
+    {
+        return $this->settings[$key] ?? null;
+    }
+
+    /**
+     * Persist many values at once.
+     *
+     * @param array $values Key/value pairs to update.
+     *
+     * @return void
+     */
+    public function update_many(array $values)
+    {
+        $this->settings = wp_parse_args($values, $this->settings);
+        update_option(static::OPTION_KEY, $this->settings);
+    }
+}

--- a/tmw-seo-autopilot-100/classes/class-task-runner.php
+++ b/tmw-seo-autopilot-100/classes/class-task-runner.php
@@ -1,0 +1,100 @@
+<?php
+namespace TMW\SA100\Classes;
+
+use WP_Error;
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Coordinates keyword research and content planning tasks.
+ */
+class Task_Runner
+{
+    /**
+     * @var Serper_Client
+     */
+    protected $serper;
+
+    /**
+     * @var OpenAI_Client
+     */
+    protected $openai;
+
+    /**
+     * @var Keyword_Engine
+     */
+    protected $engine;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(Serper_Client $serper, OpenAI_Client $openai, Keyword_Engine $engine)
+    {
+        $this->serper = $serper;
+        $this->openai = $openai;
+        $this->engine = $engine;
+    }
+
+    /**
+     * Generate a keyword plan for a set of keywords.
+     *
+     * @param array  $keywords Seed keywords.
+     * @param string $locale   Locale string.
+     *
+     * @return array|WP_Error
+     */
+    public function generate_keyword_plan(array $keywords, $locale = 'us')
+    {
+        $plan = [];
+
+        foreach ($keywords as $keyword) {
+            $keyword = sanitize_text_field($keyword);
+
+            if (empty($keyword)) {
+                continue;
+            }
+
+            $results = $this->serper->search($keyword, $locale);
+
+            if (is_wp_error($results)) {
+                return $results;
+            }
+
+            $plan[] = $this->engine->build_clusters($results, $keyword);
+        }
+
+        return [
+            'locale'   => $locale,
+            'keywords' => $plan,
+        ];
+    }
+
+    /**
+     * Generate an OpenAI content outline.
+     *
+     * @param string $topic   Article topic.
+     * @param array  $outline Optional outline hints.
+     *
+     * @return string|WP_Error
+     */
+    public function generate_content_outline($topic, array $outline = [])
+    {
+        $messages = [
+            [
+                'role'    => 'system',
+                'content' => 'You are an SEO strategist generating concise outlines with title, intro bullet, and section list.',
+            ],
+            [
+                'role'    => 'user',
+                'content' => wp_json_encode([
+                    'topic'   => sanitize_text_field($topic),
+                    'outline' => array_map('sanitize_text_field', $outline),
+                ]),
+            ],
+        ];
+
+        return $this->openai->chat($messages);
+    }
+}

--- a/tmw-seo-autopilot-100/core/class-plugin.php
+++ b/tmw-seo-autopilot-100/core/class-plugin.php
@@ -1,0 +1,249 @@
+<?php
+namespace TMW\SA100\Core;
+
+use TMW\SA100\Classes\Keyword_Engine;
+use TMW\SA100\Classes\OpenAI_Client;
+use TMW\SA100\Classes\Serper_Client;
+use TMW\SA100\Classes\Settings;
+use TMW\SA100\Classes\Task_Runner;
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Main plugin controller.
+ */
+class Plugin
+{
+    /**
+     * Plugin singleton instance.
+     *
+     * @var Plugin
+     */
+    protected static $instance;
+
+    /**
+     * Plugin settings controller.
+     *
+     * @var Settings
+     */
+    protected $settings;
+
+    /**
+     * Task runner for SEO automation routines.
+     *
+     * @var Task_Runner
+     */
+    protected $task_runner;
+
+    /**
+     * Retrieve singleton instance.
+     *
+     * @return Plugin
+     */
+    public static function get_instance()
+    {
+        if (! isset(static::$instance)) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    /**
+     * Constructor registers hooks.
+     */
+    protected function __construct()
+    {
+        $this->settings = new Settings();
+
+        add_action('admin_menu', [$this, 'register_admin_menu']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_assets']);
+        add_action('rest_api_init', [$this, 'register_rest_routes']);
+
+        $this->task_runner = new Task_Runner(
+            new Serper_Client($this->settings),
+            new OpenAI_Client($this->settings),
+            new Keyword_Engine()
+        );
+
+        add_filter('plugin_action_links_' . plugin_basename(TMW_SA100_PLUGIN_FILE), [$this, 'plugin_action_links']);
+    }
+
+    /**
+     * Activate hook - ensure cron and default options exist.
+     *
+     * @return void
+     */
+    public static function activate()
+    {
+        Settings::activate();
+    }
+
+    /**
+     * Deactivate hook - clean up scheduled tasks.
+     *
+     * @return void
+     */
+    public static function deactivate()
+    {
+        Settings::deactivate();
+    }
+
+    /**
+     * Register the plugin admin menu.
+     *
+     * @return void
+     */
+    public function register_admin_menu()
+    {
+        add_menu_page(
+            __('SEO Autopilot', 'tmw-seo-autopilot-100'),
+            __('SEO Autopilot', 'tmw-seo-autopilot-100'),
+            'manage_options',
+            'tmw-seo-autopilot-100',
+            [$this, 'render_dashboard'],
+            'dashicons-admin-site-alt3'
+        );
+
+        add_submenu_page(
+            'tmw-seo-autopilot-100',
+            __('Keyword Engine', 'tmw-seo-autopilot-100'),
+            __('Keyword Engine', 'tmw-seo-autopilot-100'),
+            'manage_options',
+            'tmw-sa100-keyword-engine',
+            [$this, 'render_keyword_engine']
+        );
+
+        add_submenu_page(
+            'tmw-seo-autopilot-100',
+            __('Integrations', 'tmw-seo-autopilot-100'),
+            __('Integrations', 'tmw-seo-autopilot-100'),
+            'manage_options',
+            'tmw-sa100-integrations',
+            [$this, 'render_integrations']
+        );
+
+        add_submenu_page(
+            'tmw-seo-autopilot-100',
+            __('Diagnostics', 'tmw-seo-autopilot-100'),
+            __('Diagnostics', 'tmw-seo-autopilot-100'),
+            'manage_options',
+            'tmw-sa100-diagnostics',
+            [$this, 'render_diagnostics']
+        );
+    }
+
+    /**
+     * Enqueue admin assets.
+     *
+     * @return void
+     */
+    public function enqueue_assets($hook_suffix)
+    {
+        if (strpos($hook_suffix, 'tmw-seo-autopilot-100') === false) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'tmw-sa100-admin',
+            plugins_url('admin/assets/admin.css', TMW_SA100_PLUGIN_FILE),
+            [],
+            TMW_SA100_VERSION
+        );
+
+        wp_enqueue_script(
+            'tmw-sa100-admin',
+            plugins_url('admin/assets/admin.js', TMW_SA100_PLUGIN_FILE),
+            ['jquery'],
+            TMW_SA100_VERSION,
+            true
+        );
+
+        wp_localize_script('tmw-sa100-admin', 'tmwSA100', [
+            'nonce'      => wp_create_nonce('wp_rest'),
+            'restUrl'    => rest_url('tmw-sa100/v1'),
+            'hasSerper'  => (bool) $this->settings->get('serper_api_key'),
+            'hasOpenAI'  => (bool) $this->settings->get('openai_api_key'),
+        ]);
+    }
+
+    /**
+     * Register custom REST routes for automation endpoints.
+     *
+     * @return void
+     */
+    public function register_rest_routes()
+    {
+        Rest_Routes::register($this->task_runner, $this->settings);
+    }
+
+    /**
+     * Render dashboard page.
+     *
+     * @return void
+     */
+    public function render_dashboard()
+    {
+        tmw_sa100_view('dashboard', [
+            'settings' => $this->settings,
+        ]);
+    }
+
+    /**
+     * Render keyword engine page.
+     *
+     * @return void
+     */
+    public function render_keyword_engine()
+    {
+        tmw_sa100_view('keyword-engine', [
+            'task_runner' => $this->task_runner,
+        ]);
+    }
+
+    /**
+     * Render integrations page.
+     *
+     * @return void
+     */
+    public function render_integrations()
+    {
+        tmw_sa100_view('integrations', [
+            'settings' => $this->settings,
+        ]);
+    }
+
+    /**
+     * Render diagnostics page.
+     *
+     * @return void
+     */
+    public function render_diagnostics()
+    {
+        tmw_sa100_view('diagnostics', [
+            'settings' => $this->settings,
+            'connection_checks' => [
+                'serper' => tmw_sa100_is_connected('https://serper.dev/'),
+                'openai' => tmw_sa100_is_connected('https://api.openai.com/v1/models'),
+                'wordpress' => tmw_sa100_is_connected(home_url()),
+            ],
+        ]);
+    }
+
+    /**
+     * Provide quick links from plugins list.
+     *
+     * @param array $links Current links.
+     *
+     * @return array
+     */
+    public function plugin_action_links(array $links)
+    {
+        $settings_link = '<a href="' . esc_url(admin_url('admin.php?page=tmw-sa100-integrations')) . '">' . __('Settings', 'tmw-seo-autopilot-100') . '</a>';
+        array_unshift($links, $settings_link);
+
+        return $links;
+    }
+}

--- a/tmw-seo-autopilot-100/core/class-rest-routes.php
+++ b/tmw-seo-autopilot-100/core/class-rest-routes.php
@@ -1,0 +1,92 @@
+<?php
+namespace TMW\SA100\Core;
+
+use TMW\SA100\Classes\Settings;
+use TMW\SA100\Classes\Task_Runner;
+use WP_REST_Request;
+use WP_Error;
+use WP_REST_Response;
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * REST API routes for the plugin automation endpoints.
+ */
+class Rest_Routes
+{
+    /**
+     * Register the namespace routes.
+     *
+     * @param Task_Runner $runner   Task runner instance.
+     * @param Settings    $settings Settings controller.
+     *
+     * @return void
+     */
+    public static function register(Task_Runner $runner, Settings $settings)
+    {
+        register_rest_route('tmw-sa100/v1', '/keyword-plan', [
+            'methods'             => 'POST',
+            'callback'            => function (WP_REST_Request $request) use ($runner) {
+                $keywords = $request->get_param('keywords');
+                $locale   = $request->get_param('locale');
+
+                if (empty($keywords)) {
+                    return new WP_Error('tmw_sa100_missing_keywords', __('Keywords are required.', 'tmw-seo-autopilot-100'), [
+                        'status' => 400,
+                    ]);
+                }
+
+                $result = $runner->generate_keyword_plan((array) $keywords, $locale);
+
+                return new WP_REST_Response($result, 200);
+            },
+            'permission_callback' => function () {
+                return current_user_can('manage_options');
+            },
+        ]);
+
+        register_rest_route('tmw-sa100/v1', '/content-draft', [
+            'methods'             => 'POST',
+            'callback'            => function (WP_REST_Request $request) use ($runner) {
+                $topic   = $request->get_param('topic');
+                $outline = $request->get_param('outline');
+
+                if (empty($topic)) {
+                    return new WP_Error('tmw_sa100_missing_topic', __('A topic is required for content drafts.', 'tmw-seo-autopilot-100'), [
+                        'status' => 400,
+                    ]);
+                }
+
+                $result = $runner->generate_content_outline($topic, (array) $outline);
+
+                return new WP_REST_Response($result, 200);
+            },
+            'permission_callback' => function () {
+                return current_user_can('manage_options');
+            },
+        ]);
+
+        register_rest_route('tmw-sa100/v1', '/settings', [
+            'methods'             => ['GET', 'POST'],
+            'callback'            => function (WP_REST_Request $request) use ($settings) {
+                if ($request->get_method() === 'GET') {
+                    return new WP_REST_Response($settings->all(), 200);
+                }
+
+                $params = $request->get_json_params();
+                $settings->update_many([
+                    'serper_api_key' => $params['serper_api_key'] ?? '',
+                    'openai_api_key' => $params['openai_api_key'] ?? '',
+                    'default_locale' => $params['default_locale'] ?? 'en',
+                ]);
+
+                return new WP_REST_Response($settings->all(), 200);
+            },
+            'permission_callback' => function () {
+                return current_user_can('manage_options');
+            },
+        ]);
+    }
+}

--- a/tmw-seo-autopilot-100/includes/helpers.php
+++ b/tmw-seo-autopilot-100/includes/helpers.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Shared helper functions for the TMW SEO Autopilot 100 plugin.
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! function_exists('tmw_sa100_view')) {
+    /**
+     * Safely load a view file.
+     *
+     * @param string $view File name without extension.
+     * @param array  $data Optional data to extract for the template.
+     *
+     * @return void
+     */
+    function tmw_sa100_view($view, array $data = [])
+    {
+        $file = plugin_dir_path(TMW_SA100_PLUGIN_FILE) . 'admin/views/' . $view . '.php';
+
+        if (! file_exists($file)) {
+            return;
+        }
+
+        if (! empty($data)) {
+            extract($data, EXTR_SKIP);
+        }
+
+        include $file;
+    }
+}
+
+if (! function_exists('tmw_sa100_is_connected')) {
+    /**
+     * Simple connectivity check using WordPress HTTP API.
+     *
+     * @param string $url URL to ping.
+     *
+     * @return bool
+     */
+    function tmw_sa100_is_connected($url)
+    {
+        $response = wp_remote_head($url, [
+            'timeout' => 5,
+        ]);
+
+        if (is_wp_error($response)) {
+            return false;
+        }
+
+        $status = wp_remote_retrieve_response_code($response);
+
+        return $status >= 200 && $status < 400;
+    }
+}

--- a/tmw-seo-autopilot-100/tmw-seo-autopilot-100.php
+++ b/tmw-seo-autopilot-100/tmw-seo-autopilot-100.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Plugin Name:       TMW SEO Autopilot 100
+ * Plugin URI:        https://themilisofialtd.com/plugins/tmw-seo-autopilot-100
+ * Description:       Phase 1 of the TMW SEO Autopilot suite providing Serper search intelligence and OpenAI content automation.
+ * Version:           1.0.0
+ * Author:            The Milisofia LTD
+ * Author URI:        https://themilisofialtd.com
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       tmw-seo-autopilot-100
+ * Domain Path:       /languages
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! defined('TMW_SA100_PLUGIN_FILE')) {
+    define('TMW_SA100_PLUGIN_FILE', __FILE__);
+}
+
+if (! defined('TMW_SA100_VERSION')) {
+    define('TMW_SA100_VERSION', '1.0.0');
+}
+
+require_once plugin_dir_path(__FILE__) . 'includes/helpers.php';
+
+/**
+ * Basic class autoloader for plugin components.
+ *
+ * @param string $class Fully qualified class name.
+ * @return void
+ */
+function tmw_sa100_autoload_classes($class)
+{
+    $map = [
+        'TMW\\SA100\\Core\\Plugin'           => 'core/class-plugin.php',
+        'TMW\\SA100\\Core\\Rest_Routes'      => 'core/class-rest-routes.php',
+        'TMW\\SA100\\Classes\\Settings'      => 'classes/class-settings.php',
+        'TMW\\SA100\\Classes\\Serper_Client' => 'classes/class-serper-client.php',
+        'TMW\\SA100\\Classes\\OpenAI_Client' => 'classes/class-openai-client.php',
+        'TMW\\SA100\\Classes\\Keyword_Engine'=> 'classes/class-keyword-engine.php',
+        'TMW\\SA100\\Classes\\Task_Runner'   => 'classes/class-task-runner.php',
+    ];
+
+    if (isset($map[$class])) {
+        $file = plugin_dir_path(__FILE__) . $map[$class];
+        if (file_exists($file)) {
+            require_once $file;
+        }
+    }
+}
+
+spl_autoload_register('tmw_sa100_autoload_classes');
+
+register_activation_hook(__FILE__, '\\TMW\\SA100\\Core\\Plugin::activate');
+register_deactivation_hook(__FILE__, '\\TMW\\SA100\\Core\\Plugin::deactivate');
+
+add_action('plugins_loaded', function () {
+    \TMW\SA100\Core\Plugin::get_instance();
+});

--- a/tmw-seo-autopilot-100/uninstall.php
+++ b/tmw-seo-autopilot-100/uninstall.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Cleanup routine for TMW SEO Autopilot 100.
+ */
+
+if (! defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}
+
+delete_option('tmw_sa100_settings');


### PR DESCRIPTION
## Summary
- add the TMW SEO Autopilot 100 plugin folder with autoloader, helpers, and activation wiring
- implement Serper/OpenAI service clients, keyword engine, and task runner used by REST and admin flows
- provide admin views, assets, and documentation for managing integrations and diagnostics

## Testing
- php -l $(find tmw-seo-autopilot-100 -name '*.php')

------
https://chatgpt.com/codex/tasks/task_e_68e40c3441988324bbbdddaea5af431a