### PR TITLE
Add TMW Slot Machine plugin v1.0.0

### DIFF
--- a/tmw-slot-machine-v1.0.0/admin/settings-page.php
+++ b/tmw-slot-machine-v1.0.0/admin/settings-page.php
@@ -1,0 +1,110 @@
+<?php
+if (!current_user_can('manage_options')) {
+    return;
+}
+
+$defaults = [
+    'win_rate'     => 20,
+    'sound'        => 'off',
+    'accent_color' => '#ff003c',
+    'offers'       => []
+];
+
+$settings = wp_parse_args(get_option('tmw_slot_machine_settings', []), $defaults);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && check_admin_referer('tmw_slot_machine_save_settings')) {
+    $settings['win_rate'] = max(1, min(100, intval($_POST['win_rate'] ?? $settings['win_rate'])));
+    $settings['sound']    = sanitize_text_field($_POST['sound'] ?? $settings['sound']);
+
+    $accent_color = sanitize_hex_color($_POST['accent_color'] ?? $settings['accent_color']);
+    $settings['accent_color'] = $accent_color ?: $defaults['accent_color'];
+
+    $titles = isset($_POST['offers_title']) ? (array) $_POST['offers_title'] : [];
+    $urls   = isset($_POST['offers_url']) ? (array) $_POST['offers_url'] : [];
+
+    $offers = [];
+    $count  = max(count($titles), count($urls));
+    for ($i = 0; $i < $count; $i++) {
+        $title = sanitize_text_field($titles[$i] ?? '');
+        $url   = esc_url_raw($urls[$i] ?? '');
+
+        if ($title && $url) {
+            $offers[] = [
+                'title' => $title,
+                'url'   => $url,
+            ];
+        }
+    }
+
+    $settings['offers'] = $offers;
+
+    update_option('tmw_slot_machine_settings', $settings);
+    echo '<div class="updated"><p>Settings saved!</p></div>';
+}
+?>
+<div class="wrap">
+    <h1>🎰 TMW Slot Machine Settings</h1>
+    <form method="post">
+        <?php wp_nonce_field('tmw_slot_machine_save_settings'); ?>
+        <table class="form-table" role="presentation">
+            <tr>
+                <th scope="row"><label for="tmw-win-rate">Win Probability (%)</label></th>
+                <td>
+                    <input id="tmw-win-rate" type="number" name="win_rate" value="<?php echo esc_attr($settings['win_rate']); ?>" min="1" max="100">
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="tmw-sound">Sound Default</label></th>
+                <td>
+                    <select id="tmw-sound" name="sound">
+                        <option value="off" <?php selected($settings['sound'], 'off'); ?>>Muted</option>
+                        <option value="on" <?php selected($settings['sound'], 'on'); ?>>On</option>
+                    </select>
+                    <p class="description">Sound is muted until the visitor toggles it on.</p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="tmw-accent-color">Accent Color</label></th>
+                <td>
+                    <input id="tmw-accent-color" type="color" name="accent_color" value="<?php echo esc_attr($settings['accent_color']); ?>">
+                    <p class="description">Controls the button and highlight color of the slot machine.</p>
+                </td>
+            </tr>
+        </table>
+
+        <h2>Featured Offers</h2>
+        <p>Add up to five LiveJasmin offers to rotate through in the slot machine results.</p>
+        <table class="widefat fixed striped">
+            <thead>
+                <tr>
+                    <th scope="col">Offer Title</th>
+                    <th scope="col">Destination URL</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php
+                $offers = $settings['offers'];
+                $max_offers = max(5, count($offers));
+                for ($i = 0; $i < $max_offers; $i++) {
+                    $offer_title = $offers[$i]['title'] ?? '';
+                    $offer_url   = $offers[$i]['url'] ?? '';
+                    ?>
+                    <tr>
+                        <td>
+                            <input type="text" name="offers_title[]" value="<?php echo esc_attr($offer_title); ?>" placeholder="70% OFF Welcome Bonus" class="regular-text">
+                        </td>
+                        <td>
+                            <input type="url" name="offers_url[]" value="<?php echo esc_attr($offer_url); ?>" placeholder="https://www.livejasmin.com/..." class="regular-text">
+                        </td>
+                    </tr>
+                    <?php
+                }
+                ?>
+            </tbody>
+        </table>
+
+        <p class="submit">
+            <input type="submit" class="button-primary" value="Save Settings">
+        </p>
+    </form>
+</div>

--- a/tmw-slot-machine-v1.0.0/assets/css/slot-machine.css
+++ b/tmw-slot-machine-v1.0.0/assets/css/slot-machine.css
@@ -1,0 +1,99 @@
+.tmw-slot-machine {
+  text-align: center;
+  background: #111;
+  color: #fff;
+  padding: 20px;
+  border-radius: 15px;
+  box-shadow: 0 0 15px var(--tmw-accent-color, #ff003c);
+  width: 320px;
+  margin: 20px auto;
+  font-family: 'Arial', sans-serif;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.tmw-branding {
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--tmw-accent-color, #ff003c);
+}
+
+.tmw-reels {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: 20px 0;
+}
+
+.reel {
+  width: 60px;
+  height: 60px;
+  background: #222;
+  border-radius: 10px;
+  box-shadow: inset 0 0 5px rgba(255, 255, 255, 0.15);
+  transition: transform 0.3s;
+  border: 2px solid rgba(255, 255, 255, 0.05);
+}
+
+.reel.spin {
+  animation: spin 0.4s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(-100%);
+  }
+}
+
+.tmw-spin-btn {
+  background: var(--tmw-accent-color, #ff003c);
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  font-weight: bold;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+  box-shadow: 0 0 12px rgba(255, 0, 60, 0.5);
+}
+
+.tmw-spin-btn:hover:not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
+}
+
+.tmw-spin-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.tmw-result {
+  margin-top: 10px;
+  font-size: 14px;
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tmw-result a {
+  color: var(--tmw-accent-color, #ff003c);
+  text-decoration: underline;
+  font-weight: bold;
+}
+
+.tmw-sound-toggle {
+  margin-top: 10px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #ccc;
+}
+
+@media (max-width: 420px) {
+  .tmw-slot-machine {
+    width: auto;
+  }
+}

--- a/tmw-slot-machine-v1.0.0/assets/js/slot-machine.js
+++ b/tmw-slot-machine-v1.0.0/assets/js/slot-machine.js
@@ -1,0 +1,117 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const containers = document.querySelectorAll('.tmw-slot-machine');
+  if (!containers.length) {
+    return;
+  }
+
+  containers.forEach(container => {
+    const btn = container.querySelector('.tmw-spin-btn');
+    const reels = container.querySelectorAll('.reel');
+    const result = container.querySelector('.tmw-result');
+    const soundToggle = container.querySelector('.tmw-sound-toggle');
+
+    if (!btn || !reels.length || !result || !soundToggle) {
+      return;
+    }
+
+    const winRate = parseFloat(container.dataset.winRate || '20');
+    let soundEnabled = (container.dataset.soundDefault || 'off') === 'on';
+    let offers = [];
+    let audioContext;
+
+    if (container.dataset.offers) {
+      try {
+        const parsed = JSON.parse(container.dataset.offers);
+        if (Array.isArray(parsed)) {
+          offers = parsed.filter(offer => offer && offer.title && offer.url);
+        }
+      } catch (error) {
+        console.error('TMW Slot Machine: invalid offers data', error);
+      }
+    }
+
+    const defaultOffer = {
+      title: 'Claim Reward',
+      url: 'https://www.livejasmin.com/en/promotions?category=girls&psid=Topmodels4u'
+    };
+
+    const ensureAudioContext = () => {
+      const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextClass) {
+        return null;
+      }
+      if (!audioContext) {
+        audioContext = new AudioContextClass();
+      }
+      return audioContext;
+    };
+
+    const playTone = (frequency, duration = 0.3) => {
+      if (!soundEnabled) {
+        return;
+      }
+      const ctx = ensureAudioContext();
+      if (!ctx) {
+        return;
+      }
+      if (ctx.state === 'suspended') {
+        ctx.resume().catch(() => {});
+      }
+      const oscillator = ctx.createOscillator();
+      const gain = ctx.createGain();
+
+      oscillator.type = 'triangle';
+      oscillator.frequency.value = frequency;
+      oscillator.connect(gain);
+      gain.connect(ctx.destination);
+
+      const now = ctx.currentTime;
+      gain.gain.setValueAtTime(0.0001, now);
+      gain.gain.exponentialRampToValueAtTime(0.2, now + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+      oscillator.start(now);
+      oscillator.stop(now + duration);
+    };
+
+    const updateSoundLabel = () => {
+      soundToggle.textContent = soundEnabled ? '🔊 Sound On' : '🔇 Enable Sound';
+    };
+
+    updateSoundLabel();
+
+    soundToggle.addEventListener('click', () => {
+      soundEnabled = !soundEnabled;
+      if (soundEnabled) {
+        const ctx = ensureAudioContext();
+        if (ctx && ctx.state === 'suspended') {
+          ctx.resume().catch(() => {});
+        }
+      }
+      updateSoundLabel();
+    });
+
+    btn.addEventListener('click', () => {
+      btn.disabled = true;
+      result.textContent = '';
+      reels.forEach(reel => reel.classList.add('spin'));
+      playTone(440, 0.25);
+
+      setTimeout(() => {
+        reels.forEach(reel => reel.classList.remove('spin'));
+        const win = Math.random() * 100 < winRate;
+        const offer = offers.length ? offers[Math.floor(Math.random() * offers.length)] : defaultOffer;
+
+        if (win) {
+          result.innerHTML = `🎉 You WON! <a href="${offer.url}" target="_blank" rel="noopener noreferrer">${offer.title}</a>`;
+          playTone(880, 0.5);
+        } else {
+          result.innerHTML = `😅 So close! Try again or <a href="${offer.url}" target="_blank" rel="noopener noreferrer">grab ${offer.title}</a>.`;
+          playTone(260, 0.2);
+        }
+
+        btn.disabled = false;
+      }, 2500);
+    });
+  });
+});

--- a/tmw-slot-machine-v1.0.0/readme.txt
+++ b/tmw-slot-machine-v1.0.0/readme.txt
@@ -1,0 +1,36 @@
+=== TMW Slot Machine ===
+Contributors: adultwebmaster69
+Tags: slot machine, gamification, affiliate, livejasmin
+Requires at least: 5.0
+Tested up to: 6.4
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A gamified "Spin & Win" slot machine for LiveJasmin affiliate promotions. Control win probability, branding, color accents, sound defaults, and featured offers to boost conversions.
+
+== Description ==
+TMW Slot Machine delivers a dopamine-driven engagement loop to promote LiveJasmin offers via a fun slot machine widget. Customize win rate, sound defaults, highlight color, and the LiveJasmin offers promoted from the WordPress admin panel.
+
+Use the `[tmw_slot_machine]` shortcode to display the slot machine anywhere on your site. The default win probability is 20%, and sound remains muted until users enable it manually.
+
+== Installation ==
+1. Upload the `tmw-slot-machine` folder to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' menu in WordPress.
+3. Configure offers, win probability, accent color, and sound defaults under **Settings → TMW Slot Machine**.
+4. Insert the `[tmw_slot_machine]` shortcode into any post or page.
+
+== Frequently Asked Questions ==
+= Can I change the win chance? =
+Yes. Adjust the percentage on the settings page to tune the win frequency.
+
+= How are offers managed? =
+Default offers are preloaded on activation. Update the offers table from the settings screen to rotate new promotions.
+
+== Changelog ==
+= 1.0.0 =
+* Initial release of the TMW Slot Machine with configurable win probability, featured offers, accent color, sound toggle, and shortcode display.
+
+== Upgrade Notice ==
+= 1.0.0 =
+Initial release.

--- a/tmw-slot-machine-v1.0.0/templates/slot-machine-display.php
+++ b/tmw-slot-machine-v1.0.0/templates/slot-machine-display.php
@@ -1,0 +1,19 @@
+<?php
+$settings = get_option('tmw_slot_machine_settings', []);
+$win_rate = $settings['win_rate'] ?? 20;
+$sound_default = $settings['sound'] ?? 'off';
+$accent_color = $settings['accent_color'] ?? '#ff003c';
+$offers = $settings['offers'] ?? [];
+$offers_json = esc_attr(wp_json_encode($offers));
+?>
+<div class="tmw-slot-machine" data-win-rate="<?php echo esc_attr($win_rate); ?>" data-sound-default="<?php echo esc_attr($sound_default); ?>" data-offers="<?php echo $offers_json; ?>" style="--tmw-accent-color: <?php echo esc_attr($accent_color); ?>;">
+  <div class="tmw-branding">By Adultwebmaster69 | Top-Models Webcam Studio</div>
+  <div class="tmw-reels">
+    <div class="reel"></div>
+    <div class="reel"></div>
+    <div class="reel"></div>
+  </div>
+  <button class="tmw-spin-btn">SPIN NOW 🎰</button>
+  <div class="tmw-result"></div>
+  <div class="tmw-sound-toggle">🔇 Enable Sound</div>
+</div>

--- a/tmw-slot-machine-v1.0.0/tmw-slot-machine.php
+++ b/tmw-slot-machine-v1.0.0/tmw-slot-machine.php
@@ -1,0 +1,80 @@
+<?php
+/*
+Plugin Name: TMW Slot Machine
+Description: Gamified LiveJasmin promotions with variable dopamine-based spin logic to boost engagement and conversions.
+Version: 1.0.0
+Author: Adultwebmaster69 | Top-Models Webcam Studio
+Author URI: https://top-models.webcam
+*/
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('TMW_SLOT_MACHINE_PATH', plugin_dir_path(__FILE__));
+define('TMW_SLOT_MACHINE_URL', plugin_dir_url(__FILE__));
+
+function tmw_slot_machine_asset_version($relative_path) {
+    $path = TMW_SLOT_MACHINE_PATH . ltrim($relative_path, '/');
+    return file_exists($path) ? filemtime($path) : false;
+}
+
+function tmw_slot_machine_enqueue_assets() {
+    wp_enqueue_style(
+        'tmw-slot-css',
+        TMW_SLOT_MACHINE_URL . 'assets/css/slot-machine.css',
+        [],
+        tmw_slot_machine_asset_version('assets/css/slot-machine.css')
+    );
+
+    wp_enqueue_script(
+        'tmw-slot-js',
+        TMW_SLOT_MACHINE_URL . 'assets/js/slot-machine.js',
+        [],
+        tmw_slot_machine_asset_version('assets/js/slot-machine.js'),
+        true
+    );
+}
+
+// Register shortcode
+add_shortcode('tmw_slot_machine', 'tmw_slot_machine_display');
+function tmw_slot_machine_display() {
+    tmw_slot_machine_enqueue_assets();
+
+    ob_start();
+    include TMW_SLOT_MACHINE_PATH . 'templates/slot-machine-display.php';
+    return ob_get_clean();
+}
+
+// Admin menu
+add_action('admin_menu', function() {
+    add_options_page('TMW Slot Machine', 'TMW Slot Machine', 'manage_options', 'tmw-slot-machine', 'tmw_slot_machine_admin_page');
+});
+
+function tmw_slot_machine_admin_page() {
+    include TMW_SLOT_MACHINE_PATH . 'admin/settings-page.php';
+}
+
+// Activation hook
+register_activation_hook(__FILE__, function() {
+    $default_settings = [
+        'win_rate'     => 20,
+        'sound'        => 'off',
+        'accent_color' => '#ff003c',
+        'offers'       => [
+            ['title' => '70% OFF Welcome Bonus', 'url' => 'https://www.livejasmin.com/en/promotions?category=girls&psid=Topmodels4u'],
+            ['title' => '10 Free Peeks', 'url' => 'https://www.livejasmin.com/en/promotions?category=girls&psid=Topmodels4u'],
+            ['title' => 'Hot Deal: Private Shows', 'url' => 'https://www.livejasmin.com/en/promotions?category=girls&psid=Topmodels4u'],
+            ['title' => '15% OFF Million Roses', 'url' => 'https://www.livejasmin.com/en/promotions?category=girls&psid=Topmodels4u'],
+            ['title' => 'Best Value – From 0.01 Credits', 'url' => 'https://www.livejasmin.com/en/promotions?category=girls&psid=Topmodels4u'],
+        ],
+    ];
+
+    $existing = get_option('tmw_slot_machine_settings');
+
+    if (!$existing) {
+        update_option('tmw_slot_machine_settings', $default_settings);
+    } else {
+        update_option('tmw_slot_machine_settings', wp_parse_args($existing, $default_settings));
+    }
+});


### PR DESCRIPTION
## Summary
- add the TMW Slot Machine plugin structure with shortcode output and default activation settings
- build an admin settings screen for tuning win rate, accent color, sound defaults, and rotating affiliate offers
- implement frontend styling, slot spin behavior, and optional audio feedback driven by configurable offers

## Testing
- php -l tmw-slot-machine-v1.0.0/tmw-slot-machine.php
- php -l tmw-slot-machine-v1.0.0/admin/settings-page.php
- php -l tmw-slot-machine-v1.0.0/templates/slot-machine-display.php

------
https://chatgpt.com/codex/tasks/task_e_68e57941be0c832491710f791a31c524